### PR TITLE
Resolve recursive symlink

### DIFF
--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -195,9 +195,8 @@ func GetExecutableDir() string {
 
 	exeDir := filepath.Dir(exe)
 
-	if link, err := os.Readlink(exe); err == nil {
-		linkDir := filepath.Dir(link)
-		return filepath.Join(exeDir, linkDir)
+	if link, err := filepath.EvalSymlinks(exe); err == nil {
+		return filepath.Dir(link)
 	}
 
 	return exeDir


### PR DESCRIPTION
This makes it work for when `spicetify` is symlinked more than once.