### PR TITLE
Improper capitalization fix on Trashbin

### DIFF
--- a/Extensions/trashbin.js
+++ b/Extensions/trashbin.js
@@ -37,8 +37,8 @@
     let trashArtistList = {};
     let userHitBack = false;
 
-    const THROW_TEXT = "Throw To Trashbin";
-    const UNTHROW_TEXT = "Take Out Of Trashbin";
+    const THROW_TEXT = "Throw to Trashbin";
+    const UNTHROW_TEXT = "Take out of Trashbin";
 
     // Fetch stored trash tracks and artists list
     if (jsonBinURL) {


### PR DESCRIPTION
Prior to this PR, Trashbin appears differently from the rest of the items in the context menu, capitalization wise. [Image](https://i.imgur.com/hSC960Z.png)