### PR TITLE
newReleases.js: Show Podcasts only and Ignore All

### DIFF
--- a/Extensions/newRelease.js
+++ b/Extensions/newRelease.js
@@ -340,7 +340,7 @@
 
     // Add context menu items for Notification button
     const checkURI = ([uri]) => uri === "spotify:special:new-release"
-    new ContextMenu.Item(
+    const podcastContextMenuItem = new ContextMenu.Item(
         "Podcast",
         function () {
             const state = !BUTTON.isFetchingPodcast()
@@ -350,7 +350,8 @@
         },
         checkURI,
         BUTTON.isFetchingPodcast() ? "check" : null,
-    ).register()
+    )
+    podcastContextMenuItem.register()
 
     new ContextMenu.Item(
         "Followed artists only",
@@ -382,6 +383,10 @@
             const state = !BUTTON.isPodcastOnly()
             BUTTON.setPodcastOnly(state)
             this.icon = state ? "check" : null
+            if (state && !BUTTON.isFetchingPodcast()) {
+                BUTTON.setFetchingPodcast(true)
+                podcastContextMenuItem.icon = "check"
+            }
             main()
         },
         checkURI,
@@ -389,6 +394,15 @@
     ).register()
 
     new ContextMenu.Item("Refresh", main, checkURI).register()
+    new ContextMenu.Item(
+        "Ignore all",
+        function () {
+            BUTTON.loadingState()
+            LIST.apply([], BUTTON.isUnlistenedOnly())
+            BUTTON.idleState()
+        },
+        checkURI
+    ).register()
 
     function getArtistList() {
         return new Promise((resolve, reject) => { CosmosAPI.resolver.get("sp://core-collection/unstable/@/list/artists/all", (err, raw) => {

--- a/Extensions/newRelease.js
+++ b/Extensions/newRelease.js
@@ -1,7 +1,7 @@
 // @ts-check
 // NAME: New Release
 // AUTHOR: khanhas
-// VERSION: 1.0
+// VERSION: 1.1
 // DESCRIPTION: Gather new releases in nice UI and easy to access
 
 /// <reference path="../globals.d.ts" />
@@ -28,6 +28,7 @@
     const FOLLOWEDONLY_SETTING_KEY = "spicetify_new_release:followed_only"
     const UNLISTENEDONLY_SETTING_KEY = "spicetify_new_release:unlistened_only"
     const PODCAST_SETTING_KEY = "spicetify_new_release:podcast"
+    const PODCASTONLY_SETTING_KEY = "spicetify_new_release:podcast_only"
 
     class ReleaseCollection {
         constructor() {
@@ -170,6 +171,9 @@
             if (!LocalStorage.get(UNLISTENEDONLY_SETTING_KEY)) {
                 this.setUnlistenedOnly(false)
             }
+            if (!LocalStorage.get(PODCASTONLY_SETTING_KEY)) {
+                this.setPodcastOnly(false)
+            }
         }
 
         update(count) {
@@ -213,6 +217,14 @@
         setFetchingPodcast(state) {
             LocalStorage.set(PODCAST_SETTING_KEY, state ? "1" : "0")
         }
+
+        isPodcastOnly() {
+            return LocalStorage.get(PODCASTONLY_SETTING_KEY) === "1"
+        }
+
+        setPodcastOnly(state) {
+            LocalStorage.set(PODCASTONLY_SETTING_KEY, state ? "1" : "0")
+        }
     }
 
     const LIST = new ReleaseCollection()
@@ -223,11 +235,7 @@
     document.querySelector("#view-browser-navigation-top-bar")
         .append(BUTTON.container)
 
-    async function main() {
-        today = new Date().getTime()
-
-        BUTTON.loadingState()
-
+    async function fetchTracks() {
         let artistList = await getArtistList()
 
         if (BUTTON.isFollowedOnly()) {
@@ -267,7 +275,15 @@
             }
         })
 
-        const items = await Promise.all(requests)
+        return await Promise.all(requests)
+    }
+
+    async function main() {
+        today = new Date().getTime()
+
+        BUTTON.loadingState()
+
+        const items = BUTTON.isPodcastOnly() ? [] : await fetchTracks()
 
         if (BUTTON.isFetchingPodcast()) {
             for (const podcast of await getPodcastList()) {
@@ -299,6 +315,7 @@
     function update() {
         LIST.setStorage(BUTTON.isFollowedOnly())
         LIST.update(BUTTON.isUnlistenedOnly())
+        LIST.update(BUTTON.isPodcastOnly())
         BUTTON.update(LIST.getUnlistenedLen())
         if (LIST.getLen() === 0) {
             LIST.setMessage(NO_NEW_RELEASE_TEXT)
@@ -357,6 +374,18 @@
         },
         checkURI,
         BUTTON.isUnlistenedOnly() ? "check" : null,
+    ).register()
+
+    new ContextMenu.Item(
+        "Podcasts only",
+        function () {
+            const state = !BUTTON.isPodcastOnly()
+            BUTTON.setPodcastOnly(state)
+            this.icon = state ? "check" : null
+            main()
+        },
+        checkURI,
+        BUTTON.isPodcastOnly() ? "check" : null,
     ).register()
 
     new ContextMenu.Item("Refresh", main, checkURI).register()


### PR DESCRIPTION
First thank you for making this amazing program!

This is my first contribution to this project so I'm sorry if I've made any mistakes.

This PR allows the newReleases.js extension to show Podcasts only. I didn't want all the new releases information because I use the Release Radar every week but I thought that having new podcast information could be useful!

I have also added an Ignore All option to clear all new release notifications.

Let me know if there is anything that needs to be fixed.