### PR TITLE
Open window in fullscreen in fullAppDisplay.js

### DIFF
--- a/Extensions/fullAppDisplay.js
+++ b/Extensions/fullAppDisplay.js
@@ -342,8 +342,12 @@ body.fad-activated #full-app-display {
             updateControl()
             Spicetify.Player.addEventListener("onplaypause", updateControl)
         }
+        if (CONFIG.enableFullscreen) {
+            document.documentElement.requestFullscreen();
+        } else {
+            document.exitFullscreen()
+        }
         document.body.classList.add(...classes)
-        document.documentElement.requestFullscreen();
     }
 
     function deactivate() {
@@ -354,8 +358,10 @@ body.fad-activated #full-app-display {
         if (CONFIG.enableControl) {
             Spicetify.Player.removeEventListener("onplaypause", updateControl)
         }
+        if (CONFIG.enableFullscreen) {
+            document.exitFullscreen()
+        }
         document.body.classList.remove(...classes)
-        document.exitFullscreen()
     }
 
     function getConfig() {
@@ -409,6 +415,7 @@ body.fad-activated #full-app-display {
     newMenuItem("Show album", "showAlbum")
     newMenuItem("Show icons", "icons")
     newMenuItem("Vertical mode", "vertical")
+    newMenuItem("Enable fullscreen", "enableFullscreen")
     new Spicetify.ContextMenu.Item("Exit", deactivate, checkURI).register()
 
     button.onclick = activate

--- a/Extensions/fullAppDisplay.js
+++ b/Extensions/fullAppDisplay.js
@@ -343,6 +343,7 @@ body.fad-activated #full-app-display {
             Spicetify.Player.addEventListener("onplaypause", updateControl)
         }
         document.body.classList.add(...classes)
+        document.documentElement.requestFullscreen();
     }
 
     function deactivate() {
@@ -354,6 +355,7 @@ body.fad-activated #full-app-display {
             Spicetify.Player.removeEventListener("onplaypause", updateControl)
         }
         document.body.classList.remove(...classes)
+        document.exitFullscreen()
     }
 
     function getConfig() {


### PR DESCRIPTION
I think that the "full app display" extension should open in fullscreen. I made two little changes to request and exit fullscreen, I saw in the zlink.bundle.js file that these are the methods used by the Spotify fullscreen functionality.