### PR TITLE
XDG base spec compliance on OSX

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -10,5 +10,6 @@ golang.org/x/net v0.0.0-20200506145744-7e3656a0809f/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -190,7 +190,7 @@ func getSpicetifyFolder() string {
 	if runtime.GOOS == "windows" {
 		result = filepath.Join(os.Getenv("USERPROFILE"), ".spicetify")
 
-	} else if runtime.GOOS == "linux" {
+	} else if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
 		parent, isAvailable := os.LookupEnv("XDG_CONFIG_HOME")
 
 		if !isAvailable || len(parent) == 0 {
@@ -200,16 +200,7 @@ func getSpicetifyFolder() string {
 
 		result = filepath.Join(parent, "spicetify")
 
-	} else if runtime.GOOS == "darwin" {
-		parent, isAvailable := os.LookupEnv("XDG_CONFIG_HOME")
-
-		if !isAvailable || len(parent) == 0 {
-			parent = os.Getenv("HOME")
-		}
-
-		result = filepath.Join(parent, "spicetify_data")
 	}
-
 	return result
 }
 

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -181,9 +181,10 @@ func GetSpotifyPath() string {
 
 func getSpicetifyFolder() string {
 	result, isAvailable := os.LookupEnv("SPICETIFY_CONFIG")
+	defer func() { utils.CheckExistAndCreate(result) }()
 
 	if isAvailable && len(result) > 0 {
-		goto OUT
+		return result
 	}
 
 	if runtime.GOOS == "windows" {
@@ -209,8 +210,6 @@ func getSpicetifyFolder() string {
 		result = filepath.Join(parent, "spicetify_data")
 	}
 
-OUT:
-	utils.CheckExistAndCreate(result)
 	return result
 }
 

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -195,7 +195,6 @@ func getSpicetifyFolder() string {
 
 		if !isAvailable || len(parent) == 0 {
 			parent = filepath.Join(os.Getenv("HOME"), ".config")
-			utils.CheckExistAndCreate(parent)
 		}
 
 		result = filepath.Join(parent, "spicetify")

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -18,11 +18,11 @@ import (
 )
 
 // CheckExistAndCreate checks folder existence
-// and make that folder if it does not exist
+// and makes that folder and any parent folders if it does not exist
 func CheckExistAndCreate(dir string) {
 	_, err := os.Stat(dir)
 	if err != nil {
-		os.Mkdir(dir, 0700)
+		os.MkdirAll(dir, 0700)
 	}
 }
 

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -90,9 +90,10 @@ func Copy(src, dest string, recursive bool, filters []string) error {
 	os.MkdirAll(dest, 0700)
 
 	for _, file := range dir {
-		fSrcPath := filepath.Join(src, file.Name())
+		filename := file.Name()
+		fSrcPath := filepath.Join(src, filename)
 
-		fDestPath := filepath.Join(dest, file.Name())
+		fDestPath := filepath.Join(dest, filename)
 		if file.IsDir() && recursive {
 			os.MkdirAll(fDestPath, 0700)
 			Copy(fSrcPath, fDestPath, true, filters)
@@ -101,7 +102,7 @@ func Copy(src, dest string, recursive bool, filters []string) error {
 				isMatch := false
 
 				for _, filter := range filters {
-					if strings.Contains(file.Name(), filter) {
+					if strings.Contains(filename, filter) {
 						isMatch = true
 						break
 					}
@@ -247,9 +248,7 @@ func CreateJunction(location, destination string) error {
 	case "windows":
 		exec.Command("cmd", "/C", "rmdir", destination).Run()
 		return exec.Command("cmd", "/C", "mklink", "/J", destination, location).Run()
-	case "linux":
-		return exec.Command("ln", "-Fsf", location, destination).Run()
-	case "darwin":
+	case "linux", "darwin":
 		return exec.Command("ln", "-Fsf", location, destination).Run()
 	}
 


### PR DESCRIPTION
A lot of people (myself included) found it strange that the spicetify folder is unhidden in `$HOME` on OSX: `~/spicetify_data`

It's easy to fix it yourself by doing 
```sh
$ export SPICETIFY_CONFIG="$HOME/.config/spicetify"
```
but it should conform to the [XDG base dir spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) by default, like it does on Linux. It's the closest thing to a cross-platform standard we have.

Alternatively, it could default to something like `$HOME/.spicetify`, as it does right now on Windows. But if we're changing the directory, we might as well make it standards compliant--most modern applications respect `$XDG_CONFIG_HOME`. Changing the Windows configuration is outside the scope of this PR.

### TODO
The basic functionality is there--the obvious caveat is backwards compatibility. I propose that we check if `~/spicetify_data` exists if `runtime.GOOS == "darwin"`, and using that as the folder if it does, falling back to 
```sh
"${XDG_CONFIG_HOME:-"$HOME/.config"}/spicetify"
``` 
otherwise. The user can move the location whenever they want, and backwards compatibility is saved. This isn't the only option though, and I'd love to hear feedback.