### PR TITLE
Fixed: Full App Display extension rendering "undefined" artist name

### DIFF
--- a/Extensions/fullAppDisplay.js
+++ b/Extensions/fullAppDisplay.js
@@ -301,7 +301,12 @@ body.fad-activated #full-app-display {
                 .trim()
         }
         title.innerText = rawTitle
-        artist.innerText = Spicetify.Player.data.track.metadata.artist_name
+        let artistName = Spicetify.Player.data.track.metadata.artist_name
+        if (artistName) {
+            artist.innerText = artistName
+        } else {
+            artist.innerText = ""
+        }
         if (CONFIG.showAlbum) {
             album_uri = Spicetify.Player.data.track.metadata.album_uri
             const albumInfo = await getAlbumInfo(album_uri.replace("spotify:album:", ""))


### PR DESCRIPTION
Fixed Full App Display extension rendering "undefined" instead of the artist name when the artist name was missing from the track metadata (which seems to be happening for some **podcasts**). 

Will skip rendering "undefined" now and render nothing instead. See the screenshots attached below.

Before the fix:

![artist-undefined](https://user-images.githubusercontent.com/216213/95815265-4f76d300-0cea-11eb-9ba6-dafe1f531b75.png)

After the fix:

![artist-undefined-fixed](https://user-images.githubusercontent.com/216213/95815301-5c93c200-0cea-11eb-9b5f-6108edfbac75.png)
