### PR TITLE
Fix typos

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -210,7 +210,7 @@ declare namespace Spicetify {
      * @param uri is optional. Leave it blank to get currrent track
      * or specify another track uri.
      */
-    function getAblumArtColors(uri?: string): Promise<{
+    function getAlbumArtColors(uri?: string): Promise<{
         DESATURATED: string;
         LIGHT_VIBRANT: string;
         PROMINENT: string;

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -93,7 +93,7 @@ const Spicetify = {
             "Queue",
             "removeFromQueue",
             "showNotification",
-            "getAblumArtColors",
+            "getAlbumArtColors",
             "Menu",
             "ContextMenu",
             "Abba",
@@ -1400,7 +1400,7 @@ Spicetify.colorExtractor = (uri) => {
     });
 }
 
-Spicetify.getAblumArtColors = async (uri) => {
+Spicetify.getAlbumArtColors = async (uri) => {
     uri = uri || Spicetify.Player.data.track.metadata.album_uri;
     return await Spicetify.colorExtractor(uri);
 }


### PR DESCRIPTION
Hi there,

As #262 mentioned, there's a small typo in `getAblumArtColors()`. It should be `getAlbumArtColors()`.
This is referenced in both `globals.d.ts` and `jsHelper/spicetifyWrapper.js`.