### PR TITLE
Add autoSkipFestive.js: skip Christmas songs

### DIFF
--- a/Extensions/autoSkipFestive.js
+++ b/Extensions/autoSkipFestive.js
@@ -26,7 +26,7 @@
         const data = Spicetify.Player.data || Spicetify.Queue;
         if (!data) return;
 
-        const regexList = [/christmas/i, /xmas/i, /santa/i, /claus/i, /mistletoe/i, /winter wonderland/i, /rudolph/i, /feliz navidad/i];
+        const regexList = [/christmas/i, /xmas/i, /santa/i, /claus/i, /mistletoe/i, /winter wonderland/i, /rudolph/i, /feliz navidad/i, /no[ëe]l/i];
         const text = data.track.metadata.title + ' ' + data.track.metadata.album_title;
         if (regexList.some(rx => rx.test(text))) {
             Spicetify.Player.next();

--- a/Extensions/autoSkipFestive.js
+++ b/Extensions/autoSkipFestive.js
@@ -1,0 +1,35 @@
+// @ts-check
+
+// NAME: Non-festive Spotify
+// AUTHOR: Zedeldi (based on https://github.com/khanhas/spicetify-cli/blob/master/Extensions/autoSkipExplicit.js)
+// VERSION: 1.0
+// DESCRIPTION: Auto skip festive songs. Toggle in Profile menu.
+
+/// <reference path="../globals.d.ts" />
+
+(function NonFestiveSpotify() {
+    if (!Spicetify.LocalStorage) {
+        setTimeout(NonFestiveSpotify, 1000);
+        return;
+    }
+
+    let isEnabled = Spicetify.LocalStorage.get("NonFestiveMode") === "1";
+
+    new Spicetify.Menu.Item("Non-festive mode", isEnabled, (self) => {
+        isEnabled = !isEnabled;
+        Spicetify.LocalStorage.set("NonFestiveMode", isEnabled ? "1" : "0");
+        self.setState(isEnabled);
+    }).register();
+
+    Spicetify.Player.addEventListener("songchange", () => {
+        if (!isEnabled) return;
+        const data = Spicetify.Player.data || Spicetify.Queue;
+        if (!data) return;
+
+        const regexList = [/christmas/i, /xmas/i, /santa/i, /claus/i, /mistletoe/i, /winter wonderland/i, /rudolph/i, /feliz navidad/i];
+        const text = data.track.metadata.title + ' ' + data.track.metadata.album_title;
+        if (regexList.some(rx => rx.test(text))) {
+            Spicetify.Player.next();
+        }
+    });
+})();


### PR DESCRIPTION
Skip festive songs, based on their title / album, using regex. Essentially search for keywords - like 'Christmas', or 'Santa Claus'. It's not an ideal solution, but as far as I can see, Spotify does not expose any method to find a track's genre or tags. The extension is based on `autoSkipExplicit.js`, and creates a menu item in the same way.

When testing with some Spotify-curated Christmas playlists, some songs with obscure names got through:
- _Underneath the Tree, Wrapped in Red_ - Kelly Clarkson
- _Man With The Bag_ - Jessie J
- _Carol of the Bells_

Proportionally, 6/94 in '_Christmas Hits_' & 4/60 in '_Christmas Classics_' slipped past, with singles more likely to miss.

This feature has been suggested before to Spotify, on multiple occasions, but never gained enough interest; this inactive [idea](https://community.spotify.com/t5/Closed-Ideas/Don-t-suggest-play-Christmas-Music-after-Christmas/idi-p/1021409), from 2015, has been requested again [here](https://community.spotify.com/t5/Live-Ideas/Playlists-Option-to-automatically-skip-Christmas-songs-outside/idi-p/4965376).

Please let me know if there is a better way to do this :)

P.S. Thanks for spicetify!
