### PR TITLE
fullAppDisplay.js: Fix song duration after skipping

### DIFF
--- a/Extensions/fullAppDisplay.js
+++ b/Extensions/fullAppDisplay.js
@@ -319,10 +319,8 @@ body.fad-activated #full-app-display {
             album.innerText = Spicetify.Player.data.track.metadata.album_title + " • " + album_date
         }
         if (CONFIG.enableProgress) {
-            // Delayed as getDuration doesn't immediately update
-            setTimeout(function (){
-                durr.innerText = Spicetify.Player.formatTime(Spicetify.Player.getDuration())
-            }, 20);
+            // Not using Spicetify.Player.getDuration() due to bug
+            durr.innerText = Spicetify.Player.formatTime(Spicetify.Player.data.track.metadata.duration)
         }
     }
 

--- a/Extensions/fullAppDisplay.js
+++ b/Extensions/fullAppDisplay.js
@@ -319,7 +319,10 @@ body.fad-activated #full-app-display {
             album.innerText = Spicetify.Player.data.track.metadata.album_title + " • " + album_date
         }
         if (CONFIG.enableProgress) {
-            durr.innerText = Spicetify.Player.formatTime(Spicetify.Player.getDuration())
+            // Delayed as getDuration doesn't immediately update
+            setTimeout(function (){
+                durr.innerText = Spicetify.Player.formatTime(Spicetify.Player.getDuration())
+            }, 20);
         }
     }
 


### PR DESCRIPTION
Fixes #312
Found that Spicetify.Player.getDuration() doesn't immediately update to the new song length after changing track so added a delay in

Delay could be lowered by more than 20ms but wasn't sure how long it needs to be delayed for, so the getDuration performs properly