### PR TITLE
newRelease.js: Add new releases menu heading

### DIFF
--- a/Extensions/newRelease.js
+++ b/Extensions/newRelease.js
@@ -495,7 +495,7 @@
 
         const heading = document.createElement("h3")
         heading.id = "new-release-heading"
-        heading.innerText = "New Releases"
+        heading.innerText = BUTTON_NAME_TEXT
 
         const items = document.createElement("ul")
 

--- a/Extensions/newRelease.js
+++ b/Extensions/newRelease.js
@@ -142,7 +142,7 @@
         }
 
         setMessage(msg) {
-            this.items.innerHTML = `<div id="new-release-message">${msg}</div>`
+            this.items.innerHTML = `<p id="new-release-message">${msg}</p>`
         }
 
         changePosition(x, y) {
@@ -318,7 +318,7 @@
         LIST.update(BUTTON.isUnlistenedOnly())
         LIST.update(BUTTON.isPodcastOnly())
         BUTTON.update(LIST.getUnlistenedLen())
-        if (LIST.getLen() === 0) {
+        if (LIST.getLen() === 0 || (BUTTON.isUnlistenedOnly() && LIST.getUnlistenedLen() === 0)) {
             LIST.setMessage(NO_NEW_RELEASE_TEXT)
         }
     }
@@ -466,8 +466,11 @@
     overflow: hidden auto;
     padding: 0 10px 10px
 }
+#new-release-menu ul {
+    margin: 0;
+}
 #new-release-message {
-    margin-top: 10px
+    text-align: center;
 }
 #new-release-heading {
     position: sticky;
@@ -486,7 +489,7 @@
     right: 0;
     bottom: 0;
     padding: 0 5px 5px 0;
-    z-index: 3
+    z-index: 3;
 }`
 
         const menu = document.createElement("div")

--- a/Extensions/newRelease.js
+++ b/Extensions/newRelease.js
@@ -474,7 +474,7 @@
     top: 0;
     margin: 0;
     padding: 1rem 0;
-    z-index: 4;
+    z-index: 5;
     font-weight: var(--glue-font-weight-black);
     text-align: center;
     letter-spacing: -.005em;

--- a/Extensions/newRelease.js
+++ b/Extensions/newRelease.js
@@ -35,7 +35,8 @@
             this.list = {}
             const menu = createMenu()
             this.container = menu.container
-            this.items = menu.menu
+            this.menu = menu.menu
+            this.items = menu.items
             this.lastScroll = 0
             this.container.onclick = () => {
                 this.storeScroll()
@@ -145,8 +146,8 @@
         }
 
         changePosition(x, y) {
-            this.items.style.left = x + "px"
-            this.items.style.top = y + 10 + "px"
+            this.menu.style.left = x + "px"
+            this.menu.style.top = y + 10 + "px"
         }
 
         storeScroll() {
@@ -468,6 +469,18 @@
 #new-release-message {
     margin-top: 10px
 }
+#new-release-heading {
+    position: sticky;
+    top: 0;
+    margin: 0;
+    padding: 1rem 0;
+    z-index: 4;
+    font-weight: var(--glue-font-weight-black);
+    text-align: center;
+    letter-spacing: -.005em;
+    color: var(--modspotify_main_fg);
+    background-color: var(--modspotify_sidebar_and_player_bg);
+}
 .new-release-controls {
     position: absolute;
     right: 0;
@@ -476,13 +489,21 @@
     z-index: 3
 }`
 
-        const menu = document.createElement("ul")
+        const menu = document.createElement("div")
         menu.id = "new-release-menu"
         menu.className = "context-menu"
 
+        const heading = document.createElement("h3")
+        heading.id = "new-release-heading"
+        heading.innerText = "New Releases"
+
+        const items = document.createElement("ul")
+
+        menu.append(heading, items)
+
         container.append(style, menu)
 
-        return { container, menu }
+        return { container, menu, items }
     }
 
     class CardContainer extends HTMLElement {


### PR DESCRIPTION
Adds a menu heading to the 'New Releases' context menu -

https://user-images.githubusercontent.com/7577851/102714389-f181ef80-4319-11eb-8489-67bce7b65831.mp4

I based the heading off of the 'Connect to a device' menu, class `.ConnectPopup__header` for consistency -

![image](https://user-images.githubusercontent.com/7577851/102714328-8506f080-4319-11eb-8a70-9058ffd4ad50.png)