### PR TITLE
fix ContextMenu deregister function, Set does not have a remove method

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1524,7 +1524,7 @@ Spicetify.ContextMenu = (function () {
             itemList.add(this);
         }
         deregister() {
-            itemList.remove(this);
+            itemList.delete(this);
         }
     }
 
@@ -1627,7 +1627,7 @@ Spicetify.ContextMenu = (function () {
 })();
 
 Spicetify.Abba = (function() {
-    const STORAGE_KEY = "Spicetify.OverrideAbbaFlags";    
+    const STORAGE_KEY = "Spicetify.OverrideAbbaFlags";
     const STORAGE = window.top.localStorage;
 
     const storedOverrideFlags = STORAGE.getItem(STORAGE_KEY);


### PR DESCRIPTION
Noticed while writing an extension that needed to deregister a created context menu item in some situations that the function was using a .remove method which does not exist on a Set object. This change switches it to the delete method so that deregister does not error now.

Console error when attempting to deregister on version 1.2.1 for reference:
```
TypeError: itemList.remove is not a function
    at Item.deregister (spicetifyWrapper.js:1527)
    at extension.js:126
```