### PR TITLE
FullAppDisplay : Fix progress bar length when controls aren't enabled

### DIFF
--- a/Extensions/fullAppDisplay.js
+++ b/Extensions/fullAppDisplay.js
@@ -267,8 +267,8 @@ body.video-full-screen.video-full-screen--hide-ui {
                     <svg height="20" width="20" viewBox="0 0 16 16" fill="currentColor">
                         ${Spicetify.SVGIcons["skip-forward"]}
                     </svg>
-                </button>` : ""}
-            </div>
+                </button>
+            </div>` : ""}
             ${CONFIG.enableProgress ? `
             <div id="fad-progress-container">
                 <span id="fad-elapsed"></span>


### PR DESCRIPTION
The end of scope for controls in html is misplaced, making the progress bar length be on the same size as the text above if controls aren't enabled.

Before :
![image](https://user-images.githubusercontent.com/11920536/119217474-b8bd9080-bada-11eb-8756-a0c4356aac7c.png)


After :
![image](https://user-images.githubusercontent.com/11920536/119217445-9166c380-bada-11eb-8e70-7ea215f18344.png)
