### PR TITLE
Extra Dracula color

### DIFF
--- a/Themes/SpicetifyDefault/color.ini
+++ b/Themes/SpicetifyDefault/color.ini
@@ -103,6 +103,7 @@ notification-error = e22134
 misc               = BFBFBF
 
 [dracula]
+; Dracula with orange accents
 text               = FFFFFF
 subtext            = d8dee9
 main               = 282a36
@@ -116,6 +117,24 @@ button-active      = ffb86c
 button-disabled    = 535353
 tab-active         = 44475a
 notification       = ffb86c
+notification-error = e22134
+misc               = BFBFBF
+
+[dracula2]
+; Dracula with purple accents
+text               = FFFFFF
+subtext            = d8dee9
+main               = 282a36
+sidebar            = 282a36
+player             = 282a36
+card               = 6272a4
+shadow             = 44475a
+selected-row       = F0F0F0
+button             = bd93f9
+button-active      = bd93f9
+button-disabled    = 535353
+tab-active         = 44475a
+notification       = 50fa7b
 notification-error = e22134
 misc               = BFBFBF
 


### PR DESCRIPTION
Add extra color for Dracula variant. More Dracul'ish...

Image for reference:
![Screenshot_1](https://user-images.githubusercontent.com/37307597/120110327-506f4e80-c16d-11eb-89f4-c4f2fcbde0a2.jpg)

Maybe this method will work? It worked in Dribbblish...
