### PR TITLE
Fix multiple hooks and extensions breaking on new Spotify (Solves #845)

### DIFF
--- a/Extensions/loopyLoop.js
+++ b/Extensions/loopyLoop.js
@@ -7,7 +7,7 @@
 /// <reference path="../globals.d.ts" />
 
 (function LoopyLoop(){
-    const bar = document.querySelector(".playback-bar .progress-bar");
+    const bar = document.querySelector(".playback-bar > div:nth-child(2)");
     if (!bar) {
         setTimeout(LoopyLoop, 100);
         return;

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -27,8 +27,8 @@ const Spicetify = {
             }
             Spicetify.Player.origin.seekTo(p);
         },
-        getProgress: () => Spicetify.Player.origin._state.position,
-        getProgressPercent: () => (Spicetify.Player.origin._state.position/Spicetify.Player.origin._state.duration),
+        getProgress: () => Date.now() - Spicetify.Player.origin2.state.position.timestamp + Spicetify.Player.origin2.state.position.position,
+        getProgressPercent: () => ((Date.now() - Spicetify.Player.origin2.state.position.timestamp + Spicetify.Player.origin2.state.position.position)/Spicetify.Player.origin._state.duration),
         getDuration: () => Spicetify.Player.origin._state.duration,
         setVolume: (v) => { Spicetify.Player.origin.setVolume(v) },
         increaseVolume: () => { Spicetify.Player.origin.setVolume(Spicetify.Player.getVolume() + 0.15) },

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -27,8 +27,8 @@ const Spicetify = {
             }
             Spicetify.Player.origin.seekTo(p);
         },
-        getProgress: () => Date.now() - Spicetify.Player.origin2.state.position.timestamp + Spicetify.Player.origin2.state.position.position,
-        getProgressPercent: () => ((Date.now() - Spicetify.Player.origin2.state.position.timestamp + Spicetify.Player.origin2.state.position.position)/Spicetify.Player.origin._state.duration),
+        getProgress: () => (Spicetify.Player.origin._state.isPaused ? 0 : Date.now() - Spicetify.Player.origin2.state.position.timestamp) + Spicetify.Player.origin2.state.position.position,
+        getProgressPercent: () => (Spicetify.Player.getProgress()/Spicetify.Player.origin._state.duration),
         getDuration: () => Spicetify.Player.origin._state.duration,
         setVolume: (v) => { Spicetify.Player.origin.setVolume(v) },
         increaseVolume: () => { Spicetify.Player.origin.setVolume(Spicetify.Player.getVolume() + 0.15) },

--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -157,7 +157,7 @@ func insertCustomApp(jsPath string, flags Flag) {
 			"Custom app React symbols",
 			content,
 			[]string{
-				`lazy\(\(\(\)=>(\w+)\.(\w+)\(\d+\).then\(\w+\.bind\(\w+,\d+\)\)\)\)`})
+				`lazy\(\(function\(\)\{return (\w+)\.(\w+)\(\d+\).then\(\w+\.bind\(\w+,\d+\)\)\}\)\)`})
 		eleSymbs := utils.FindSymbol(
 			"Custom app React Element",
 			content,
@@ -176,7 +176,7 @@ func insertCustomApp(jsPath string, flags Flag) {
 			appNameArray += fmt.Sprintf(`"%s",`, app)
 
 			appReactMap += fmt.Sprintf(
-				`,spicetifyApp%d=Spicetify.React.lazy((()=>%s.%s("%s").then(%s.bind(%s,"%s"))))`,
+				`,spicetifyApp%d=Spicetify.React.lazy((function(){return %s.%s("%s").then(%s.bind(%s,"%s"))}))`,
 				index, reactSymbs[0], reactSymbs[1],
 				appName, reactSymbs[0], reactSymbs[0], appName)
 
@@ -194,7 +194,7 @@ func insertCustomApp(jsPath string, flags Flag) {
 
 		utils.ReplaceOnce(
 			&content,
-			`lazy\(\(\(\)=>[\w\.]+\(\d+\)\.then\(\w+\.bind\(\w+,\d+\)\)\)\)`,
+			`lazy\(\(function\(\)\{return [\w\.]+\(\d+\).then\(\w+\.bind\(\w+,\d+\)\)\}\)\)`,
 			`${0}`+appReactMap)
 
 		utils.ReplaceOnce(

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -312,14 +312,14 @@ Spicetify.React.useEffect(() => {
 	// React Component: Context Menu and Right Click Menu
 	utils.Replace(
 		&input,
-		`(const \w+)(=\w+=>\w+\(\)\.createElement\(([\w\.]+),\w+\(\)\(\{\},\w+,\{action:"open",trigger:"right-click"\}\)\)\})`,
-		`Spicetify.ReactComponent.ContextMenu=${3};${1}=Spicetify.ReactComponent.RightClickMenu${2}`)
+		`return (\w+\(\)\.createElement\(([\w\.]+),\w+\(\)\(\{\},\w+,\{action:"open",trigger:"right-click"\}\)\))`,
+		`Spicetify.ReactComponent.ContextMenu=${2};Spicetify.ReactComponent.RightClickMenu=${1};return Spicetify.ReactComponent.RightClickMenu`)
 
 	// React Component: Context Menu - Menu
 	utils.Replace(
 		&input,
-		`=\(\{children:\w+,onClose:\w+,getInitialFocusElement:\w+\}\)`,
-		`=Spicetify.ReactComponent.Menu${0}`)
+		`return (\w+\(\)\.createElement\("ul",\w+\(\)\(\{tabIndex:-?\d+,ref:\w+,role:"menu","data-depth":\w+\},\w+\),\w+\))`,//`\w+\(\)\.createElement\([\w\.]+,\{onClose:[\w\.]+,getInitialFocusElement:`,//`\w+\(\)\.createElement\([\w\.]+,\{className:[\w\.]+,onClose:[\w\.]+,onKeyDown:[\w\.]+,onKeyUp:[\w\.]+,getInitialFocusElement:[\w\.]+\},[\w\.]+\)`,
+		`return Spicetify.ReactComponent.Menu=${1}`)
 
 	// React Component: Context Menu - Menu Item
 	utils.Replace(

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -199,8 +199,9 @@ func colorVariableReplaceForJS(content string) string {
 
 func disableSentry(input string) string {
 	// utils.Replace(&input, `sentry\.install\(\)[,;]`, "")
-	utils.Replace(&input, `;if\(\w+\.type===\w+\.\w+\.LOG_INTERACTION`, ";return${0}")
-	utils.Replace(&input, `\("https://\w+@sentry.io/\d+"`, `;("https://null@127.0.0.1/0"`)
+	// TODO Broken hooks
+	//utils.Replace(&input, `;if\(\w+\.type===\w+\.\w+\.LOG_INTERACTION`, ";return${0}")
+	//utils.Replace(&input, `\("https://\w+@sentry.io/\d+"`, `;("https://null@127.0.0.1/0"`)
 	return input
 }
 

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -258,10 +258,11 @@ func exposeAPIs_main(input string) string {
 		`\w+\(\)\.createElement\(\w+,\{onChange:this\.handleSaberStateChange\}\),`,
 		"")
 
-	utils.Replace(
+	// React Hook
+	utils.ReplaceOnce(
 		&input,
-		`;class \w+ extends (\w+)\(\).Component`,
-		`;Spicetify.React=${1}()${0}`)
+		`\w+=\(\w+,(\w+)\.lazy\)\(\(function\(\)\{return Promise\.resolve\(\)\.then\(\w+\.bind\(\w+,\w+\)\)\}\)\);`,
+		`${0}Spicetify.React=${1};`)
 
 	utils.Replace(
 		&input,

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -279,15 +279,13 @@ func exposeAPIs_main(input string) string {
 			// set t = e.sent, call Promise.all for APIs, then add Spicetify APIs to object
 			code := found[1] + ";" + found[2] + ".then(v => {Spicetify.Platform = {};"
 
-			i := 0
-			for _, apiFunc := range splitted {
+			for apiFuncIndex, apiFunc := range splitted {
 				name := re.ReplaceAllString(apiFunc, `${1}`)
 
 				if strings.HasPrefix(name, "get") {
 					name = strings.Replace(name, "get", "", 1)
 				}
-				code += "Spicetify.Platform[\"" + name + "\"] = v[" + fmt.Sprint(i) + "];"
-				i = i + 1
+				code += "Spicetify.Platform[\"" + name + "\"] = v[" + fmt.Sprint(apiFuncIndex) + "];"
 			}
 			code += "});"
 			// Promise.all(...).then(...); return t = e.sent, e.next = 6, Promise.all(...);


### PR DESCRIPTION
This fixes multiple major hooks which were broken, the second step that #870 was missing. This PR includes #870 and solves #845.

I have tested and ran this on the newest Spotify, it works very well.

With a build of this PR Spotify should display properly again.

## PATCH DOWNLOAD + INSTRUCTIONS TO FIX FOR NEW SPOTIFY

 https://github.com/itsmeowForks/spicetify-cli/releases/tag/v2.5.0-patch4

## Fixed hooks by PR
 - `Spicetify.React`
 - `Spicetify.Platform`
 - `Spicetify.Player.getProgress()`
 - `Spicetify.Player.getProgressPercent()`
 - `Spicetify.ReactComponent.ContextMenu`
 - `Spicetify.ReactComponent.RightClickMenu`
 - `Spicetify.ReactComponent.Menu`

## Known currently broken hooks

 - Remove star wars easter egg
 - disable_sentry (**This is completely removed**, regardless of config settings, as of patch4. Disabling this is no longer necessary)
 - disable_logging
 - `Spicetify.Menu`
 - `Spicetify.ReactComponent.MenuItem`
 - `Spicetify.ReactComponent.AlbumMenu`
 - `Spicetify.ReactComponent.PodcastShowMenu`
 - `Spicetify.ReactComponent.ArtistMenu`
 - `Spicetify.ReactComponent.PlaylistMenu`

## Known issues

- Some apps will not work due to the above broken hooks (let me know if any hooks you use are listed above as broken!)

## loopyLoop.js Fix

patch4 currently doesn't include this, you can fix it yourself by downloading and replacing the [loopyLoop.js from the repo](https://raw.githubusercontent.com/itsmeowForks/spicetify-cli/master/Extensions/loopyLoop.js) or manually updating it as so:

Open up `spicetify-cli/Extensions/loopyLoop.js`

Change:
```js
const bar = document.querySelector(".playback-bar .progress-bar");
```

to

```js
const bar = document.querySelector(".playback-bar > div:nth-child(2)");
```
