### PR TITLE
Add minor version tag support for CSS mappings

### DIFF
--- a/spicetify.go
+++ b/spicetify.go
@@ -33,6 +33,9 @@ func init() {
 		utils.PrintError("Unsupported OS.")
 		os.Exit(1)
 	}
+	if version == "" {
+		version = "Dev"
+	}
 
 	log.SetFlags(0)
 	// Supports print color output for Windows

--- a/src/cmd/backup.go
+++ b/src/cmd/backup.go
@@ -59,6 +59,7 @@ func Backup(spicetifyVersion string) {
 	utils.PrintBold("Preprocessing:")
 
 	preprocess.Start(
+		spicetifyVersion,
 		rawFolder,
 		preprocess.Flag{
 			DisableSentry:  preprocSection.Key("disable_sentry").MustBool(false),

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -295,7 +295,7 @@ func CheckUpgrade(version string) {
 		return
 	}
 
-	latestTag, err := FetchLatestTag()
+	latestTag, err := utils.FetchLatestTag()
 
 	if err != nil {
 		utils.PrintError("Cannot fetch latest release info")

--- a/src/cmd/upgrade.go
+++ b/src/cmd/upgrade.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -13,13 +11,9 @@ import (
 	"github.com/khanhas/spicetify-cli/src/utils"
 )
 
-type githubRelease struct {
-	TagName string `json:"tag_name"`
-}
-
 func Upgrade(currentVersion string) {
 	utils.PrintBold("Fetch latest release info:")
-	tagName, err := FetchLatestTag()
+	tagName, err := utils.FetchLatestTag()
 	if err != nil {
 		utils.PrintError("Cannot fetch latest release info")
 		utils.PrintError(err.Error())
@@ -104,23 +98,4 @@ func permissionError(err error) {
 	utils.PrintInfo("If fatal error is \"Permission denied\", please check read/write permission of spicetify executable directory.")
 	utils.PrintInfo("However, if you used a package manager to install spicetify, please upgrade by using the same package manager.")
 	utils.Fatal(err)
-}
-
-func FetchLatestTag() (string, error) {
-	res, err := http.Get("https://api.github.com/repos/khanhas/spicetify-cli/releases/latest")
-	if err != nil {
-		return "", err
-	}
-
-	body, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return "", err
-	}
-
-	var release githubRelease
-	if err = json.Unmarshal(body, &release); err != nil {
-		return "", err
-	}
-
-	return release.TagName[1:], nil
 }

--- a/src/utils/vcs.go
+++ b/src/utils/vcs.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+)
+
+type GithubRelease struct {
+	TagName string `json:"tag_name"`
+}
+
+func FetchLatestTag() (string, error) {
+	res, err := http.Get("https://api.github.com/repos/khanhas/spicetify-cli/releases/latest")
+	if err != nil {
+		return "", err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var release GithubRelease
+	if err = json.Unmarshal(body, &release); err != nil {
+		return "", err
+	}
+
+	return release.TagName[1:], nil
+}


### PR DESCRIPTION
Will now only pull from highest minor version tag (ex: 2.6.x) instead of master branch, allowing for moderate backwards compatibility. This change also makes the development builds (ones without a version tag) use local CSS mappings only, for convenience.