### PR TITLE
Fix for Spotify 1.1.67

### DIFF
--- a/CustomApps/lyrics-plus/Utils.js
+++ b/CustomApps/lyrics-plus/Utils.js
@@ -1,10 +1,11 @@
 class Utils {
     static addQueueListener(callback) {
-        Spicetify.Player.origin2.state.addExtendedStatusListener(callback);
+        Spicetify.Player.origin2.state.addQueueListener(callback);
     }
 
     static removeQueueListener(callback) {
-        Spicetify.Player.origin2.state.removeExtendedStatusListener(callback);
+        Spicetify.Player.origin2.state.queueListeners =
+          Spicetify.Player.origin2.state.queueListeners.filter(v => v == callback);
     }
 
     static convertIntToRGB(colorInt, div = 1) {

--- a/CustomApps/lyrics-plus/Utils.js
+++ b/CustomApps/lyrics-plus/Utils.js
@@ -5,7 +5,7 @@ class Utils {
 
     static removeQueueListener(callback) {
         Spicetify.Player.origin2.state.queueListeners =
-          Spicetify.Player.origin2.state.queueListeners.filter(v => v == callback);
+          Spicetify.Player.origin2.state.queueListeners.filter(v => v != callback);
     }
 
     static convertIntToRGB(colorInt, div = 1) {

--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -217,7 +217,7 @@ class LyricsContainer extends react.Component {
         this.onQueueChange = async (queue) => {
             this.state.explicitMode = this.state.lockMode;
             this.currentTrackUri = queue.track.uri;
-            const [nextTrack] = queue.future;
+            const nextTrack = queue.next_tracks[0];
             const nextInfo = this.infoFromTrack(nextTrack);
             if (!nextInfo) {
                 this.fetchLyrics(queue.track, this.state.explicitMode);

--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -154,7 +154,7 @@ func getColorCSS(scheme map[string]string) string {
 func insertCustomApp(jsPath string, flags Flag) {
 	utils.ModifyFile(jsPath, func(content string) string {
 		const REACT_REGEX = `lazy\(\(\(\)=>(\w+)\.(\w+)\(\d+\)\.then\(\w+\.bind\(\w+,\d+\)\)\)\)`
-		const REACT_ELEMENT_REGEX = `createElement\(([\w\.]+),\{path:"\/collection"\}`
+		const REACT_ELEMENT_REGEX = `\w+\(\)\.createElement\(([\w\.]+),\{path:"\/collection"\}`
 		reactSymbs := utils.FindSymbol(
 			"Custom app React symbols",
 			content,

--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -153,16 +153,18 @@ func getColorCSS(scheme map[string]string) string {
 
 func insertCustomApp(jsPath string, flags Flag) {
 	utils.ModifyFile(jsPath, func(content string) string {
+		const REACT_REGEX = `lazy\(\(\(\)=>(\w+)\.(\w+)\(\d+\)\.then\(\w+\.bind\(\w+,\d+\)\)\)\)`
+		const REACT_ELEMENT_REGEX = `createElement\(([\w\.]+),\{path:"\/collection"\}`
 		reactSymbs := utils.FindSymbol(
 			"Custom app React symbols",
 			content,
 			[]string{
-				`lazy\(\(function\(\)\{return (\w+)\.(\w+)\(\d+\).then\(\w+\.bind\(\w+,\d+\)\)\}\)\)`})
+				REACT_REGEX})
 		eleSymbs := utils.FindSymbol(
 			"Custom app React Element",
 			content,
 			[]string{
-				`createElement\(([\w\.]+),\{path:"\/collection"\}`})
+				REACT_ELEMENT_REGEX})
 
 		appMap := ""
 		appReactMap := ""
@@ -176,7 +178,7 @@ func insertCustomApp(jsPath string, flags Flag) {
 			appNameArray += fmt.Sprintf(`"%s",`, app)
 
 			appReactMap += fmt.Sprintf(
-				`,spicetifyApp%d=Spicetify.React.lazy((function(){return %s.%s("%s").then(%s.bind(%s,"%s"))}))`,
+				`,spicetifyApp%d=Spicetify.React.lazy((()=>%s.%s("%s").then(%s.bind(%s,"%s"))))`,
 				index, reactSymbs[0], reactSymbs[1],
 				appName, reactSymbs[0], reactSymbs[0], appName)
 
@@ -194,12 +196,12 @@ func insertCustomApp(jsPath string, flags Flag) {
 
 		utils.ReplaceOnce(
 			&content,
-			`lazy\(\(function\(\)\{return [\w\.]+\(\d+\).then\(\w+\.bind\(\w+,\d+\)\)\}\)\)`,
+			REACT_REGEX,
 			`${0}`+appReactMap)
 
 		utils.ReplaceOnce(
 			&content,
-			`\w+\(\)\.createElement\([\w\.]+,\{path:"\/collection"\}`,
+			REACT_ELEMENT_REGEX,
 			appEleMap+`${0}`)
 
 		utils.Replace(

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -263,7 +263,7 @@ func exposeAPIs_main(input string) string {
 	// React Hook
 	utils.ReplaceOnce(
 		&input,
-		`\w+=\(\w+,(\w+)\.lazy\)\(\(function\(\)\{return Promise\.resolve\(\)\.then\(\w+\.bind\(\w+,\w+\)\)\}\)\);`,
+		`\w+=\(\w+,(\w+)\.lazy\)\(\(\(\)=>Promise\.resolve\(\)\.then\(\w+\.bind\(\w+,\w+\)\)\)\);`,
 		`${0}Spicetify.React=${1};`)
 
 	utils.Replace(
@@ -312,14 +312,14 @@ Spicetify.React.useEffect(() => {
 	// React Component: Context Menu and Right Click Menu
 	utils.Replace(
 		&input,
-		`return (\w+\(\)\.createElement\(([\w\.]+),\w+\(\)\(\{\},\w+,\{action:"open",trigger:"right-click"\}\)\))`,
-		`Spicetify.ReactComponent.ContextMenu=${2};Spicetify.ReactComponent.RightClickMenu=${1};return Spicetify.ReactComponent.RightClickMenu`)
+		`=(\w+)=>(\w+\(\)\.createElement\(([\w\.]+),\(\w+,[\w\.]+\)\(\{\},\w+,\{action:"open",trigger:"right-click"\}\)\))`,
+		`=Spicetify.ReactComponent.RightClickMenu=${1}=>${2};Spicetify.ReactComponent.ContextMenu=${3}`)
 
 	// React Component: Context Menu - Menu
 	utils.Replace(
 		&input,
-		`return (\w+\(\)\.createElement\("ul",\w+\(\)\(\{tabIndex:-?\d+,ref:\w+,role:"menu","data-depth":\w+\},\w+\),\w+\))`,//`\w+\(\)\.createElement\([\w\.]+,\{onClose:[\w\.]+,getInitialFocusElement:`,//`\w+\(\)\.createElement\([\w\.]+,\{className:[\w\.]+,onClose:[\w\.]+,onKeyDown:[\w\.]+,onKeyUp:[\w\.]+,getInitialFocusElement:[\w\.]+\},[\w\.]+\)`,
-		`return Spicetify.ReactComponent.Menu=${1}`)
+		`=\(\{children:\w+,onClose:\w+,getInitialFocusElement:\w+\}\)`,
+		`=Spicetify.ReactComponent.Menu${0}`)
 
 	// React Component: Context Menu - Menu Item
 	utils.Replace(


### PR DESCRIPTION
Fixes #1029 #1020 #980 #983 #989 #1003 #1039 #1022

### Fixes

- Error: Custom React App Symbols not found
- `Spicetify.React`
- `Spicetify.Platform`
- `Spicetify.ReactComponent.RightClickMenu`
- `Spicetify.ReactComponent.ContextMenu`
- `Spicetify.ReactComponent.Menu`
- Lyrics Plus (changes in internal APIs)

### Known issues/broken hooks

- `Spicetify.Menu`
- CSS mapping issues

On another note, the list of broken hooks from #945 under `Spicetify.ReactComponent` has fixed itself, so that's one less thing to worry about.