### PR TITLE
fix: type error in getProgress

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -27,7 +27,7 @@ const Spicetify = {
             }
             Spicetify.Player.origin.seekTo(p);
         },
-        getProgress: () => (Spicetify.Player.origin._state.isPaused ? 0 : Date.now() - Spicetify.Player.origin2.state.position.timestamp) + Spicetify.Player.origin2.state.position.position,
+        getProgress: () => (Spicetify.Player.origin._state.isPaused ? 0 : Date.now() - Spicetify.Player.origin._state.timestamp) + Spicetify.Player.origin._state.positionAsOfTimestamp,
         getProgressPercent: () => (Spicetify.Player.getProgress()/Spicetify.Player.origin._state.duration),
         getDuration: () => Spicetify.Player.origin._state.duration,
         setVolume: (v) => { Spicetify.Player.origin.setVolume(v) },


### PR DESCRIPTION
`Player` hook structure changed and broke the `getProgress` function, fixed it by using another available function to calculate the progress.

Tested on latest Spotify version;  1.1.68