### PR TITLE
Fix for Spotify 1.1.68

### DIFF
--- a/CustomApps/lyrics-plus/Pages.js
+++ b/CustomApps/lyrics-plus/Pages.js
@@ -40,8 +40,7 @@ const SyncedLyricsPage = react.memo(
         const [position, setPosition] = useState(0);
         useTrackPosition(() => {
             if (!Player.data.is_paused) {
-                const playback = Spicetify.Player.origin2.state.playback;
-                setPosition(playback.position_as_of_timestamp + (Date.now() - playback.timestamp));
+                setPosition(Spicetify.Player.getProgress());
             }
         });
 

--- a/Extensions/popupLyrics.js
+++ b/Extensions/popupLyrics.js
@@ -567,13 +567,14 @@ function PopupLyrics() {
             const { width, height } = ctx.canvas;
             ctx.imageSmoothingEnabled = false;
             ctx.save();
-            ctx.filter = `blur(${userConfigs.blurSize}px)`;
+            let blurSize = Number(userConfigs.blurSize);
+            ctx.filter = `blur(${blurSize}px)`;
             ctx.drawImage(
                 image,
-                -blur * 2,
-                -blur * 2 - (width - height) / 2,
-                width + 4 * blur,
-                width + 4 * blur
+                -blurSize * 2,
+                -blurSize * 2 - (width - height) / 2,
+                width + 4 * blurSize,
+                width + 4 * blurSize
             );
             ctx.restore();
             ctx.fillStyle = "#000000b0";

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -155,7 +155,7 @@ const Spicetify = {
 // Wait for Spicetify.Player.origin and origin2 to be available
 // before adding following APIs
 (function waitOrigins() {
-    if (!Spicetify.Player.origin || !Spicetify.Player.origin2) {
+    if (!Spicetify.Player || !Spicetify.Player.origin || !Spicetify.Player.origin2 || !Spicetify.Player.origin._state) {
         setTimeout(waitOrigins, 10);
         return;
     }
@@ -179,11 +179,11 @@ const Spicetify = {
         }
     );
 
-    Spicetify.Player.origin2.state.addProgressListener((data) => {
+    setInterval(() => {
         const event = new Event("onprogress");
-        event.data = data.position;
+        event.data = Spicetify.Player.getProgress();
         Spicetify.Player.dispatchEvent(event);
-    });
+    }, 1);
 
     Spicetify.addToQueue = Spicetify.Player.origin2.player.addToQueue;
     Spicetify.removeFromQueue = Spicetify.Player.origin2.removeFromQueue;

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -333,7 +333,7 @@ Spicetify.React.useEffect(() => {
 	// React Component: Context Menu and Right Click Menu
 	utils.Replace(
 		&input,
-		`=(\w+)=>(\w+\(\)\.createElement\(([\w\.]+),\(\w+,[\w\.]+\)\(\{\},\w+,\{action:"open",trigger:"right-click"\}\)\))`,
+		`=(\w+)=>(\w+\(\)\.createElement\(([\w\.]+),\w*\((\w+,[\w\.]+)?\)\(\{\},\w+,\{action:"open",trigger:"right-click"\}\)\))`,
 		`=Spicetify.ReactComponent.RightClickMenu=${1}=>${2};Spicetify.ReactComponent.ContextMenu=${3}`)
 
 	// React Component: Context Menu - Menu


### PR DESCRIPTION
Fixes #1076
Fixes #1062

# Fixes
- `Spicetify.ReactComponent.ContextMenu` and `Spicetify.ReactComponent.RightClickMenu` hooks (This fixes Lyrics Plus React minified error)
- Lyrics Plus progress issue
- Workaround for addProgressListener being removed
- Popup lyrics background being black (bug introduced in 116a5b4c9053b8c2287de139bf8e4f7ea3d9fadd)
