### PR TITLE
Fix for 1.1.69

### DIFF
--- a/CustomApps/lyrics-plus/Utils.js
+++ b/CustomApps/lyrics-plus/Utils.js
@@ -1,10 +1,10 @@
 class Utils {
     static addQueueListener(callback) {
-        Spicetify.Player.origin2.state.addQueueListener(callback);
+        Spicetify.Player.origin._events.addListener("queue_update", callback);
     }
 
     static removeQueueListener(callback) {
-        Spicetify.Player.origin2.state.queueListeners = Spicetify.Player.origin2.state.queueListeners.filter((v) => v != callback);
+        Spicetify.Player.origin._events.removeListener("queue_update", callback);
     }
 
     static convertIntToRGB(colorInt, div = 1) {

--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -216,12 +216,13 @@ class LyricsContainer extends react.Component {
 
     componentDidMount() {
         this.onQueueChange = async (queue) => {
+            queue = queue.data;
             this.state.explicitMode = this.state.lockMode;
-            this.currentTrackUri = queue.track.uri;
-            const nextTrack = queue.next_tracks[0];
+            this.currentTrackUri = queue.current.uri;
+            const nextTrack = queue.nextUp[0];
             const nextInfo = this.infoFromTrack(nextTrack);
             if (!nextInfo) {
-                this.fetchLyrics(queue.track, this.state.explicitMode);
+                this.fetchLyrics(queue.current, this.state.explicitMode);
                 return;
             }
             // Debounce queue change emitter
@@ -229,7 +230,7 @@ class LyricsContainer extends react.Component {
                 return;
             }
             this.nextTrackUri = nextInfo.uri;
-            await this.fetchLyrics(queue.track, this.state.explicitMode);
+            await this.fetchLyrics(queue.current, this.state.explicitMode);
             this.viewPort.scrollTo(0, 0);
             // Fetch next track
             this.tryServices(nextInfo, this.state.explicitMode);

--- a/CustomApps/new-releases/Card.js
+++ b/CustomApps/new-releases/Card.js
@@ -15,8 +15,7 @@ class Card extends react.Component {
     }
 
     play(event) {
-        const api = Spicetify.Player.origin2 || Spicetify.PlaybackControl.playUri;
-        api.playUri(this.uri);
+        Spicetify.Player.playUri(this.uri, this.context);
         event.stopPropagation();
     }
 

--- a/CustomApps/reddit/Card.js
+++ b/CustomApps/reddit/Card.js
@@ -26,8 +26,7 @@ class Card extends react.Component {
     }
 
     play(event) {
-        const api = Spicetify.Player.origin2 || Spicetify.PlaybackControl.playUri;
-        api.playUri(this.uri);
+        Spicetify.Player.playUri(this.uri, this.context);
         event.stopPropagation();
     }
 

--- a/Extensions/bookmark.js
+++ b/Extensions/bookmark.js
@@ -7,7 +7,7 @@
 /// <reference path="../globals.d.ts" />
 
 (function Bookmark() {
-    const { CosmosAsync, Player, LocalStorage, PlaybackControl, ContextMenu, URI } = Spicetify;
+    const { CosmosAsync, Player, LocalStorage, ContextMenu, URI } = Spicetify;
     if (!(CosmosAsync && URI)) {
         setTimeout(Bookmark, 300);
         return;
@@ -433,23 +433,19 @@
     }
 
     function onPlayClick(info) {
-        console.log(info);
+        let uri = info.uri;
         const options = {};
         if (info.time) {
-            options.offset = info.time;
+            options.seekTo = info.time;
         }
-
         if (info?.context?.startsWith("/")) {
-            const uri = URI.fromString(info.context).toURI();
-
-            const trackUid = info.context.split("?uid=", 2)[1];
-            options.trackUid = trackUid;
-
-            Spicetify.PlaybackControl.playContext({ uri, url: "context://" + uri }, options);
-            return;
+            uri = URI.fromString(info.context).toURI();
+            options.skipTo = {};
+            options.skipTo.uid = info.context.split("?uid=", 2)[1];
+            options.skipTo.uri = info.uri;
         }
 
-        Spicetify.PlaybackControl.playUri(info.uri, options);
+        Spicetify.Player.playUri(uri, {}, options);
     }
 
     const fetchAlbum = async (uri) => {

--- a/Extensions/keyboardShortcut.js
+++ b/Extensions/keyboardShortcut.js
@@ -383,14 +383,17 @@ function VimBind() {
             findButton.click();
             return;
         }
-
+        alert("Let me know where you found this button, please. I can't click this for you without that information.");
+        return;
         // TableCell case where play button is hidden
         // Index number is in first column
         const index = parseInt(element.firstChild.innerText) - 1;
         const context = getContextUri();
         if (index >= 0 && context) {
-            console.log(index, context);
-            Spicetify.PlaybackControl.playFromResolver(context, { index }, () => {});
+            console.log(index);
+            console.log(context);
+
+            //Spicetify.PlaybackControl.playFromResolver(context, { index }, () => {});
             return;
         }
     }

--- a/Extensions/popupLyrics.js
+++ b/Extensions/popupLyrics.js
@@ -128,8 +128,9 @@ function PopupLyrics() {
                 body = body.message.body.macro_calls;
 
                 if (body["matcher.track.get"].message.header.status_code !== 200) {
+                    let head = body["matcher.track.get"].message.header;
                     return {
-                        error: `Requested error: ${body["matcher.track.get"].message.header.mode}`,
+                        error: `Requested error: ${head.status_code}: ${head.hint} - ${head.mode}`,
                     };
                 }
 

--- a/Extensions/shuffle+.js
+++ b/Extensions/shuffle+.js
@@ -7,7 +7,7 @@
 /// <reference path="../globals.d.ts" />
 
 (function ShufflePlus() {
-    if (!Spicetify.CosmosAsync || !Spicetify.Player.origin2 || !Spicetify.Platform) {
+    if (!Spicetify.CosmosAsync || !Spicetify.Player.origin || !Spicetify.Platform) {
         setTimeout(ShufflePlus, 1000);
         return;
     }
@@ -18,7 +18,7 @@
         menuItem.isEnabled = playDiscography;
     });
 
-    let playUriOGFunc = Spicetify.Player.origin2.playUri.bind(Spicetify.Player.origin2);
+    let playUriOGFunc = Spicetify.Player.origin.play.bind(Spicetify.Player.origin);
     let playerPlayOGFunc = Spicetify.Platform.PlayerAPI.play.bind(Spicetify.Platform.PlayerAPI);
     let isInjected = localStorage.getItem("shuffleplus:on") === "true";
     injectFunctions(isInjected);
@@ -34,9 +34,9 @@
 
     function injectFunctions(bool) {
         if (bool) {
-            Spicetify.Player.origin2.playUri = (uri, options) => {
+            Spicetify.Player.origin.play = (uri, context, options) => {
                 if (options?.trackUid) {
-                    playUriOGFunc(uri, options);
+                    playUriOGFunc(uri, context, options);
                     return;
                 }
                 fetchAndPlay(uri);
@@ -56,7 +56,7 @@
             };
         } else {
             // Revert
-            Spicetify.Player.origin2.playUri = playUriOGFunc;
+            Spicetify.Player.origin.play = playUriOGFunc;
             Spicetify.Platform.PlayerAPI.play = playerPlayOGFunc;
         }
     }
@@ -330,7 +330,7 @@
             });
         }
         await Spicetify.CosmosAsync.put("sp://player/v2/main/queue", {
-            revision: Spicetify.Queue?.revision,
+            queue_revision: Spicetify.Queue?.revision,
             next_tracks: list.map((uri) => ({
                 uri,
                 provider: context ? "context" : "queue",

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -178,6 +178,13 @@ declare namespace Spicetify {
          */
         function play(): void;
         /**
+         * Play a track, playlist, album, etc. immediately
+         * @param uri Spotify URI
+         * @param context
+         * @param options
+         */
+        async function playUri(uri: string, context: any = {}, options: Options = {});
+        /**
          * Unregister added event listener `type`.
          * @param type
          * @param callback
@@ -419,26 +426,6 @@ declare namespace Spicetify {
      * so new extension should use this library instead.
      */
      function Mousetrap(element?: any): void;
-
-    /**
-     * Use to force playing a track/episode/album/show/playlist/artist URI.
-     */
-    namespace PlaybackControl {
-        async function resume();
-        async function pause();
-        async function nextTrack();
-        async function previousTrack();
-        async function addToQueue(uri: string);
-        async function playTracks(trackList: ContextTrack[], options: ContextOption = {});
-        async function playUri(uri: string, options: Options = {});
-        async function playCollection(trackUri: string, sort: string, filter: string);
-        async function seek(positionInMs: number);
-        async function setShuffle(enabled: boolean);
-        async function setRepeatMode(repeat: 0 | 1 | 2);
-        async function setPrivateSession(enabled: boolean);
-        async function setPreferredSubtitle(language: string): Promise<void>;
-        async function getPreferredSubtitle(): Promise<string>;
-    }
 
     /**
      * Contains vast array of internal APIs.

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1,6 +1,6 @@
 const Spicetify = {
     get CosmosAsync() {return Spicetify.Player.origin?._cosmos},
-    get Queue() {return Spicetify.Player.origin2?.state.currentQueue},
+    get Queue() {return Spicetify.Player.origin?._queue?._state},
     Player: {
         addEventListener: (type, callback) => {
             if (!(type in Spicetify.Player.eventListeners)) {
@@ -61,6 +61,9 @@ const Spicetify = {
         getHeart: () => document.querySelector('.control-button-heart button')?.ariaChecked === "true",
         pause: () => { Spicetify.Player.origin.pause() },
         play: () => { Spicetify.Player.origin.resume() },
+        playUri: async (uri, context = {}, options = {}) => {
+            return await Spicetify.Player.origin.play({uri: uri}, context, options);
+        },
         removeEventListener: (type, callback) => {
             if (!(type in Spicetify.Player.eventListeners)) {
                 return;
@@ -82,18 +85,28 @@ const Spicetify = {
             "Player",
             "addToQueue",
             "CosmosAsync",
-            "Event",
-            "EventDispatcher",
             "getAudioData",
             "Keyboard",
             "URI",
             "LocalStorage",
-            "PlaybackControl",
             "Queue",
             "removeFromQueue",
             "showNotification",
             "Menu",
             "ContextMenu",
+            "React",
+            "Mousetrap",
+            "Locale",
+            "ReactDOM",
+            "Topbar",
+            "ReactComponent",
+            "PopupModal",
+            "_cloneSidebarItem",
+            "_sidebarItemToClone",
+            "SVGIcons",
+            "colorExtractor",
+            "test",
+            "Platform"
         ];
 
         const PLAYER_METHOD = [
@@ -130,6 +143,7 @@ const Spicetify = {
             "togglePlay",
             "toggleRepeat",
             "toggleShuffle",
+            "origin"
         ]
 
         let count = SPICETIFY_METHOD.length;
@@ -149,13 +163,24 @@ const Spicetify = {
             }
         })
         console.log(`${count}/${PLAYER_METHOD.length} Spicetify.Player methods and objects are OK.`)
+
+        Object.keys(Spicetify).forEach(key => {
+            if(!SPICETIFY_METHOD.includes(key)) {
+                console.log(`Spicetify method ${key} exists but is not in the method list. Consider adding it.`)
+            }
+        })
+
+        Object.keys(Spicetify.Player).forEach(key => {
+            if(!PLAYER_METHOD.includes(key)) {
+                console.log(`Spicetify.Player method ${key} exists but is not in the method list. Consider adding it.`)
+            }
+        })
     }
 };
 
-// Wait for Spicetify.Player.origin and origin2 to be available
-// before adding following APIs
+// Wait for Spicetify.Player.origin._state before adding following APIs
 (function waitOrigins() {
-    if (!Spicetify.Player || !Spicetify.Player.origin || !Spicetify.Player.origin2 || !Spicetify.Player.origin._state) {
+    if (!Spicetify?.Player?.origin?._state) {
         setTimeout(waitOrigins, 10);
         return;
     }
@@ -185,9 +210,8 @@ const Spicetify = {
         Spicetify.Player.dispatchEvent(event);
     }, 100);
 
-    Spicetify.addToQueue = Spicetify.Player.origin2.player.addToQueue;
-    Spicetify.removeFromQueue = Spicetify.Player.origin2.removeFromQueue;
-    Spicetify.PlaybackControl = Spicetify.Player.origin2.player;
+    Spicetify.addToQueue = Spicetify.Player.origin._queue.addToQueue;
+    Spicetify.removeFromQueue = Spicetify.Player.origin._queue.removeFromQueue;
 })();
 
 Spicetify.getAudioData = async (uri) => {

--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -206,7 +206,7 @@ func insertCustomApp(jsPath string, flags Flag) {
 
 		utils.Replace(
 			&content,
-			`\w+\(\)\.createElement\("li",\{className:\w+\},\w+\(\)\.createElement\(\w+,\{uri:"spotify:user:@:collection",to:"/collection"\}`,
+			`\w+\(\)\.createElement\("li",\{className:[\w$]+\},\w+\(\)\.createElement\(\w+,\{uri:"spotify:user:@:collection",to:"/collection"\}`,
 			`Spicetify._sidebarItemToClone=${0}`)
 
 		utils.ReplaceOnce(
@@ -216,7 +216,7 @@ func insertCustomApp(jsPath string, flags Flag) {
 
 		sidebarItemMatch := utils.SeekToCloseParen(
 			content,
-			`\("li",\{className:\w+\},\w+\(\)\.createElement\(\w+,\{uri:"spotify:user:@:collection",to:"/collection"\}`,
+			`\("li",\{className:[\w$]+\},\w+\(\)\.createElement\(\w+,\{uri:"spotify:user:@:collection",to:"/collection"\}`,
 			'(', ')')
 
 		content = strings.Replace(

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -265,11 +265,6 @@ func exposeAPIs_main(input string) string {
 		`this\._cosmos=(\w+),this\._defaultFeatureVersion=\w+`,
 		`(globalThis.Spicetify.Player.origin=this),${0}`)
 
-	utils.Replace(
-		&input,
-		`,this.player=\w+,`,
-		`,(globalThis.Spicetify.Player.origin2=this)${0}`)
-
 	// Show Notification
 	utils.Replace(
 		&input,
@@ -300,12 +295,12 @@ func exposeAPIs_main(input string) string {
 		`"data-testid":`,
 		`"":`)
 
-	reAllAPIPromises := regexp.MustCompile(`return{version:\w+,(\w+:[\w!\,\(\)\.]+,)+((get\w+:\(\)=>\w+,?)+)}`)
+	reAllAPIPromises := regexp.MustCompile(`return ?{version:\w+,(?:\w+:[\w!,().]+,)+(?:get\w+:(?:async)?\(\)=>[()\w=>{} ]+,)?((?:get\w+:\(\)=>(?:[\w$]+|[(){}]+),?)+)}`)
 	allAPIPromises := reAllAPIPromises.FindAllStringSubmatch(input, -1)
 	for _, found := range allAPIPromises {
-		splitted := strings.Split(found[2], ",")
+		splitted := strings.Split(found[1], ",")
 		if len(splitted) > 15 { // Actual number is about 34
-			matchMap := regexp.MustCompile(`get(\w+):\(\)=>(\w+),?`)
+			matchMap := regexp.MustCompile(`get(\w+):\(\)=>([\w$]+|[(){}]+),?`)
 			code := "Spicetify.Platform={};"
 			for _, apiFunc := range splitted {
 				matches := matchMap.FindStringSubmatch(apiFunc)
@@ -377,6 +372,12 @@ Spicetify.React.useEffect(() => {
 		&input,
 		`this\._dictionary=\{\},`,
 		`${0}Spicetify.Locale=this,`)
+
+	// Prevent breaking popupLyrics
+	utils.Replace(
+		&input,
+		`document.pictureInPictureElement&&\(\w+.current=[!\w]+,document\.exitPictureInPicture\(\)\),\w+\.current=null`,
+		``)
 
 	return input
 }


### PR DESCRIPTION
Fixes #1112

This one's a doozy

# Changes
- **BREAKING:** Removes `Spicetify.PlaybackControl`
- **BREAKING:** Removes hook `Spicetify.Player.origin2`
- Adds `Spicetify.Player.playUri(uri, context, options)` (replacement for `Spicetify.PlaybackControl.playUri`)
- Fixes Lyrics Plus queue callback
- Fixes New Releases/Reddit Card play button
- Fixes `bookmark.js` play seeking
- Improves popupLyrics error messaging
- Fixes `shuffle+.js` play injection
- Fixes `Spicetify.Queue`
- Updates `Spicetify.test()` to reflect actual contents of Spicetify object
- Adds additional checks to `Spicetify.test()` for new contents
- Fixes `Spicetify.addToQueue` and `Spicetify.removeFromQueue`
- Fixes hook `Spicetify._sidebarItemToClone`
- Fixes hook `Spicetify._cloneSidebarItem`
- Fixes hook `Spicetify.Platform`
- Adds hook to disable a call to `document.exitPictureInPicture()` from the client itself, resulting in `popupLyrics.js` randomly exiting.