### PR TITLE
Fix for 1.1.71

### DIFF
--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -287,7 +287,7 @@ func exposeAPIs_main(input string) string {
 	// React Hook
 	utils.ReplaceOnce(
 		&input,
-		`\w+=\(\w+,(\w+)\.lazy\)\(\(\(\)=>Promise\.resolve\(\)\.then\(\w+\.bind\(\w+,\w+\)\)\)\);`,
+		`\w+=\(\w+,(\w+)\.lazy\)\(?\(\(\)=>\w+\.\w+\((?:\d+)?\)\.then\(\w+\.bind\(\w+,\w+\)\)\)\)?;`,
 		`${0}Spicetify.React=${1};`)
 
 	utils.Replace(


### PR DESCRIPTION
Fixes #1204

This changes the `Spicetify.React` hook, and is fully functional on Spotify 1.1.71.
It is also backwards compatible with 1.1.69, as the regex matches both versions.

# Test Results
![image](https://user-images.githubusercontent.com/10366817/139533073-aefa6a73-bf0f-4497-b377-756fdcf71b94.png)
