### PR TITLE
Spicetify.ContextMenu improvement: Add support for arbitrary nesting levels in context menus

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -745,6 +745,34 @@ Spicetify.ContextMenu = (function () {
 
     SubMenu.iconList = iconList;
 
+    function _addItemsRecursive(instance, currentItem, uris, uids, contextUri) {
+        if (currentItem._items?.size) {
+            const htmlSubmenu = new _HTMLContextSubmenu({
+                placement: instance.firstChild.dataset.placement,
+            });
+
+            for (const child of currentItem._items) {
+                if (!child.shouldAdd(uris, uids, contextUri)) {
+                    continue;
+                }
+
+                child._element.onclick = () => {
+                    if (!child._disabled) {
+                        child.onClick(uris, uids, contextUri);
+                        htmlSubmenu.remove();
+                        instance._tippy?.props?.onClickOutside();
+                    }
+                };
+                htmlSubmenu.addItem(child._element);
+
+                _addItemsRecursive(instance, child, uris, uids, contextUri);
+            }
+
+            currentItem._submenuElement = htmlSubmenu;
+            currentItem.disabled = currentItem._disabled;
+        }
+    }
+
     function _addItems(instance) {
         const list = instance.querySelector("ul");
         const container = instance.firstChild;
@@ -779,23 +807,7 @@ Spicetify.ContextMenu = (function () {
             }
 
             if (item._items?.size) {
-                const htmlSubmenu = new _HTMLContextSubmenu({
-                    placement: instance.firstChild.dataset.placement,
-                });
-
-                for (const child of item._items) {
-                    child._element.onclick = () => {
-                        if (!child._disabled) {
-                            child.onClick(uris, uids, contextUri);
-                            htmlSubmenu.remove();
-                            instance._tippy?.props?.onClickOutside();
-                        }
-                    };
-                    htmlSubmenu.addItem(child._element);
-                }
-
-                item._submenuElement = htmlSubmenu;
-                item.disabled = item._disabled;
+                _addItemsRecursive(instance, item, uris, uids, contextUri);
                 elemList.push(item._element);
                 continue;
             }


### PR DESCRIPTION
Hi!
While working on a custom extension I've noticed that one cannot create nested submenus in context menu. Everything that are defined deeper than level 2 was simply ignored. The PR contains a fix for that.

Given extension:

```javascript
(function Test(){
    if (!(Spicetify.ContextMenu)) {
        setTimeout(Test, 1000);
        return;
    }

    const subMenu = new Spicetify.ContextMenu.SubMenu(
        "Test_1",
        [
            new Spicetify.ContextMenu.Item("Test_1.1", (uris) => {}, (uris) => true), 
            new Spicetify.ContextMenu.SubMenu(
                "Test_1.2",
                [
                    new Spicetify.ContextMenu.Item("Test_1.2.1", (uris) => {}, (uris) => true),
                    new Spicetify.ContextMenu.Item("Test_1.2.2", (uris) => {}, (uris) => true),
                    new Spicetify.ContextMenu.SubMenu(
                        "Test_1.2.3",
                        [
                            new Spicetify.ContextMenu.Item("Test_1.2.3.1", (uris) => {}, (uris) => true),
                            new Spicetify.ContextMenu.Item("Test_1.2.3.2", (uris) => {}, (uris) => true),
                            
                        ],
                        (uris) => true
                    ),
                    new Spicetify.ContextMenu.SubMenu(
                        "Test_1.2.4",
                        [
                            new Spicetify.ContextMenu.Item("Test_1.2.4.1", (uris) => {}, (uris) => true),
                            new Spicetify.ContextMenu.Item("Test_1.2.4.2", (uris) => {}, (uris) => true),
                            
                        ],
                        (uris) => true
                    )
                ],
                (uris) => true
            )
        ],
        (uris) => true
    );

    subMenu.register();
})();
```

Looks like this before the fix:
![before-fix](https://user-images.githubusercontent.com/17597433/140612011-e3038441-7994-4da8-99b8-6f65707d2db3.jpg)

After the fix:
![after-fix](https://user-images.githubusercontent.com/17597433/140612018-b5e0208e-5c03-4434-8813-96e26fb8ec82.jpg)

