### PR TITLE
Open File explorer with -c and -config commands

### DIFF
--- a/spicetify.go
+++ b/spicetify.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"runtime"
 
 	"github.com/khanhas/spicetify-cli/src/cmd"
@@ -60,6 +62,20 @@ func init() {
 		switch v {
 		case "-c", "--config":
 			fmt.Println(cmd.GetConfigPath())
+			switch runtime.GOOS{
+            case "windows":
+                com := exec.Command(`explorer`, filepath.Dir(cmd.GetConfigPath()))
+                com.Run()
+            case "darwin":
+                com := exec.Command(`open`, filepath.Dir(cmd.GetConfigPath()))
+                com.Run()
+            case "linux":
+                com:= exec.Command(`xdg-open`,filepath.Dir(cmd.GetConfigPath()))
+                com.Run()
+            default: 
+                fmt.Println("Unsupported OS or File explorer.")
+            }
+
 			os.Exit(0)
 		case "-h", "--help":
 			kind := ""


### PR DESCRIPTION
With mac, the config file was changed to a hidden folder for cleanness purposes, however, users are typically unable to access those without following special steps (Which many inexperienced users may not be capable of.) This provides them with support