### PR TITLE
Add new css mapping for x-categoryCard-CategoryCard

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -1210,6 +1210,7 @@
     "UfG99HH3A33iKFbfpEM8": "x-carousel-rightButtonContainer",
     "zLi41yEQivjU_kR6lUTy": "x-carousel-title",
     "IyZpbhJE52K9fkJmGbAj": "x-categoryCard-CategoryCard",
+    "Em2LrSSfvrgXQoajs6cm": "x-categoryCard-CategoryCard",
     "vlweuBnMDKsbBxkuNp_o": "x-categoryCard-image",
     "xdQqah8TLoDK155FGT6e": "x-categoryCard-title",
     "_GVuKFHd7xr1QUKi_aWH": "x-downloadButton-DownloadButton",


### PR DESCRIPTION
I think this is how you're supposed to do it? It should fix this issue with the podcast card showing up in search for my extension https://github.com/theRealPadster/spicetify-hide-podcasts/issues/23

![image](https://user-images.githubusercontent.com/1565883/146683615-8b0c919b-5b97-4a9c-9cdd-e2943e6ce88d.png)
