### PR TITLE
Update mapping for .x-searchInput-searchInputInput

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -1258,6 +1258,7 @@
     "CPgTPk9wPOVigmNI6xWP": "x-searchInput-searchInputIcon",
     "mCoaW_xbXtY1_uzuUKu_": "x-searchInput-searchInputIconContainer",
     "dIwMadpRrW1PwEwEeAbN": "x-searchInput-searchInputInput",
+    "QO9loc33XC50mMRUCIvf": "x-searchInput-searchInputInput",
     "Y_y159Y1ahiDoouerBGc": "x-searchInput-searchInputSearchIcon",
     "ykgAekxoU7qDuZW1LnRV": "x-searchPage-searchPageGrid",
     "r0ztq943n9F_84Fo6MPi": "x-settings-button",


### PR DESCRIPTION
Fix css mapping for the search input on v1.1.74

Related to: https://github.com/theRealPadster/spicetify-hide-podcasts/issues/23