### PR TITLE
Select parent element, so dribbblish's custom search box will be selected

### DIFF
--- a/Extensions/keyboardShortcut.js
+++ b/Extensions/keyboardShortcut.js
@@ -165,7 +165,7 @@
      * @param {KeyboardEvent} event
      */
     function openSearchPage(event) {
-        const searchInput = document.querySelector(".main-topBar-topbarContentWrapper input");
+        const searchInput = document.querySelector(".main-topBar-container input");
         if (searchInput) {
             searchInput.focus();
         } else {


### PR DESCRIPTION
Dribbblish has its own search box, it would be nice if keyboardShortcut.js would select it instead.
