### PR TITLE
CSS map: update 'queue-tabBar-header'

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -1129,6 +1129,7 @@
     "r1WWMKiO1G1JXTGc5ASd": "progress-bar__slider",
     "pLwpjUDpZgzSXNOsGn_c": "queue-tabBar-active",
     "J3PCQkumqg15ssE0s__6": "queue-tabBar-chevron",
+    "OEFWODerafYHGp09iLlA": "queue-tabBar-header",
     "UNl7YnDOXhtw0wA0i8a4": "queue-tabBar-header",
     "B4fs9E1WWRvnKx8sDi8j": "queue-tabBar-headerItem",
     "Q_l4uPvvOxpfyG6inlGg": "queue-tabBar-headerItemLink",


### PR DESCRIPTION
CSS map update for 'queue-tabBar-header' class name. "OEFWODerafYHGp09iLlA" => "queue-tabBar-header"

Related to the Podcasts tab (Your Library page) issue in hidePodcasts extension:
https://github.com/theRealPadster/spicetify-hide-podcasts/issues/24