### PR TITLE
Add `spicetify` to `$PATH` on linux

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-# Copyright 2019 khanhas. GPL license.
+# Copyright 2022 khanhas. GPL license.
 # Edited from project Denoland install script (https://github.com/denoland/deno_install)
 param (
   [string] $version

--- a/install.sh
+++ b/install.sh
@@ -31,8 +31,8 @@ fi
 spicetify_install="$HOME/.spicetify"
 path="export PATH=\"\$PATH:\$HOME/.spicetify\""
 
-if [[ -f "$HOME/.bashrc" ]] && ! grep -q "$path" "$HOME/.bashrc"; then echo "${path}" >>"$HOME/.bashrc"; fi
-if [[ -f "$HOME/.zshrc" ]] && ! grep -q "$path" "$HOME/.zshrc"; then echo "${path}" >>"$HOME/.zshrc"; fi
+if [[ -f "$HOME/.bashrc" ]] && ! grep -q "$path" "$HOME/.bashrc"; then echo "${path}" >>"$HOME/.bashrc" && echo "SAVING         ${spicetify_install} to \$PATH"; fi
+if [[ -f "$HOME/.zshrc" ]] && ! grep -q "$path" "$HOME/.zshrc"; then echo "${path}" >>"$HOME/.zshrc" && echo "SAVING         ${spicetify_install} to \$PATH"; fi
 
 exe="$spicetify_install/spicetify"
 

--- a/install.sh
+++ b/install.sh
@@ -29,11 +29,10 @@ else
 fi
 
 spicetify_install="$HOME/.spicetify"
-path="export PATH=$PATH:${spicetify_install}"
+path="export PATH=\"\$PATH:\$HOME/.spicetify\""
 
-if [[ -f "$HOME/.zshenv" ]] && ! grep -q "$spicetify_install" "$HOME/.zshenv"; then echo "${path}" >> "$HOME/.zshenv"; fi
-if [[ -f "$HOME/.bashrc" ]] && ! grep -q "$spicetify_install" "$HOME/.bashrc"; then echo "${path}" >> "$HOME/.bashrc"; fi
-if [[ -f "$HOME/.zshrc" ]] && ! grep -q "$spicetify_install" "$HOME/.zshrc"; then echo "${path}" >> "$HOME/.zshrc"; fi
+if [[ -f "$HOME/.bashrc" ]] && ! grep -q "$path" "$HOME/.bashrc"; then echo "${path}" >>"$HOME/.bashrc"; fi
+if [[ -f "$HOME/.zshrc" ]] && ! grep -q "$path" "$HOME/.zshrc"; then echo "${path}" >>"$HOME/.zshrc"; fi
 
 exe="$spicetify_install/spicetify"
 

--- a/install.sh
+++ b/install.sh
@@ -1,20 +1,22 @@
 #!/bin/sh
-# Copyright 2019 khanhas. GPL license.
+# Copyright 2022 khanhas. GPL license.
 # Edited from project Denoland install script (https://github.com/denoland/deno_install)
 
 set -e
 
 case $(uname -sm) in
-    "Darwin x86_64") target="darwin-amd64" ;;
-    "Darwin arm64") target="darwin-arm64" ;;
-    "Linux x86_64") target="linux-amd64" ;;
-    *) echo "Unsupported platform $(uname -sm). Only Darwin x86_64, Darwin arm64 and Linux x86_64 binaries are available."
-    exit ;;
+"Darwin x86_64") target="darwin-amd64" ;;
+"Darwin arm64") target="darwin-arm64" ;;
+"Linux x86_64") target="linux-amd64" ;;
+*)
+	echo "Unsupported platform $(uname -sm). Only Darwin x86_64, Darwin arm64 and Linux x86_64 binaries are available."
+	exit
+	;;
 esac
 
 if [ $# -eq 0 ]; then
-    latest_release_uri="https://api.github.com/repos/khanhas/spicetify-cli/releases/latest"
-    echo "DOWNLOADING    $latest_release_uri"
+	latest_release_uri="https://api.github.com/repos/khanhas/spicetify-cli/releases/latest"
+	echo "DOWNLOADING    $latest_release_uri"
 	spicetify_asset_path=$(
 		command curl -sSf "$latest_release_uri" |
 			command grep -o "/khanhas/spicetify-cli/releases/download/.*/spicetify-.*-${target}\\.tar\\.gz" |
@@ -26,21 +28,22 @@ else
 	download_uri="https://github.com/khanhas/spicetify-cli/releases/download/v${1}/spicetify-${1}-${target}.tar.gz"
 fi
 
-spicetify_install="$HOME/spicetify-cli"
+spicetify_install="$HOME/.spicetify"
 
 if [[ "$target" == *"darwin"* ]]; then
-	spicetify_install="$HOME/.spicetify"
 	rcFile="$HOME/.zshenv"
+else
+	rcFile="$HOME/.profile"
+fi
 
-	if ! grep -q "$spicetify_install" "$rcFile"; then
-		echo "export PATH=${spicetify_install}:$PATH" >> "$rcFile"
-	fi
+if ! grep -q "$spicetify_install" "$rcFile"; then
+	echo "export PATH=$PATH:${spicetify_install}" >>"$rcFile"
 fi
 
 exe="$spicetify_install/spicetify"
 
 if [ ! -d "$spicetify_install" ]; then
-  echo "Creating $spicetify_install";
+	echo "Creating $spicetify_install"
 	mkdir -p "$spicetify_install"
 fi
 
@@ -61,7 +64,8 @@ rm "$tar_file"
 echo ""
 echo "spicetify was installed successfully to $exe"
 echo ""
-if command -v spicetify > /dev/null; then
+
+if command -v spicetify >/dev/null; then
 	echo "Run 'spicetify --help' to get started"
 elif [[ "$spicetify_install" == *".spicetify"* ]]; then
 	echo "Please restart your Terminal to have spicetify in your PATH."
@@ -71,6 +75,6 @@ else
 	echo "Manually add the directory to your \$HOME/.bash_profile (or similar)"
 	echo "  export SPICETIFY_INSTALL=\"$spicetify_install\""
 	echo "  export PATH=\"\$SPICETIFY_INSTALL:\$PATH\""
-    echo ""
+	echo ""
 	echo "Run '$exe --help' to get started"
 fi

--- a/install.sh
+++ b/install.sh
@@ -29,16 +29,11 @@ else
 fi
 
 spicetify_install="$HOME/.spicetify"
+path="export PATH=$PATH:${spicetify_install}"
 
-if [[ "$target" == *"darwin"* ]]; then
-	rcFile="$HOME/.zshenv"
-else
-	rcFile="$HOME/.profile"
-fi
-
-if ! grep -q "$spicetify_install" "$rcFile"; then
-	echo "export PATH=$PATH:${spicetify_install}" >>"$rcFile"
-fi
+if [[ -f "$HOME/.zshenv" ]] && ! grep -q "$spicetify_install" "$HOME/.zshenv"; then echo "${path}" >> "$HOME/.zshenv"; fi
+if [[ -f "$HOME/.bashrc" ]] && ! grep -q "$spicetify_install" "$HOME/.bashrc"; then echo "${path}" >> "$HOME/.bashrc"; fi
+if [[ -f "$HOME/.zshrc" ]] && ! grep -q "$spicetify_install" "$HOME/.zshrc"; then echo "${path}" >> "$HOME/.zshrc"; fi
 
 exe="$spicetify_install/spicetify"
 

--- a/install_curl.ps1
+++ b/install_curl.ps1
@@ -1,4 +1,4 @@
-# Copyright 2019 khanhas. GPL license.
+# Copyright 2022 khanhas. GPL license.
 # Edited from project Denoland install script (https://github.com/denoland/deno_install)
 param (
   [string] $version


### PR DESCRIPTION
After opening https://github.com/afonsojramos/spicetify-docs/pull/11 the question of whether or not adding to path on Linux was happening at the `install.sh` script was raised. After a quick look at it, it did seem that it was not happening.

This PR, in theory, fixes it, however, I do not have a full linux machine so if anyone could test this I'd be grateful, otherwise, I'll try to test on a VM, but I haven't had much time lately.

I took two Stack Overflow threads into consideration ([#1](https://stackoverflow.com/a/20054809) and [#2](https://superuser.com/a/183980)), which is why I set the path in `.profile`.

Tagging @theRealPadster and @CharlieS1103 for visibility.