### PR TITLE
Fixes for expFeatures.js

### DIFF
--- a/jsHelper/expFeatures.js
+++ b/jsHelper/expFeatures.js
@@ -106,12 +106,12 @@ button.switch[disabled] {
             return container;
         }
 
-        for (const propName in resolver.propertySet.properties) {
-            const prop = resolver.propertySet.properties[propName].spec;
+        for (const propIndex in resolver.properties) {
+            const prop = resolver.properties[propIndex];
 
             if (prop.type !== "bool") continue;
 
-            content.appendChild(createSlider(propName, prop.description, resolver.activeProperties[propName].value));
+            content.appendChild(createSlider(prop.name, prop.description, resolver.activeProperties[prop.name].value));
         }
     })();
 })();

--- a/jsHelper/expFeatures.js
+++ b/jsHelper/expFeatures.js
@@ -68,6 +68,12 @@ button.switch[disabled] {
         }
 
         for (const propName in overrideList) {
+            if (!resolver.activeProperties[propName]) {
+                delete overrideList[propName];
+                localStorage.setItem("spicetify-exp-features", JSON.stringify(overrideList));
+                continue;
+            }
+
             resolver.activeProperties[propName].value = overrideList[propName];
         }
 


### PR DESCRIPTION
This PR fixes an error caused by setting a property on `activeProperties` that doesn't exist (anymore?). The property was retrieved from localStorage. In my case the key was '58'.

It also fixes https://github.com/khanhas/spicetify-cli/issues/1417. The experimental features didn't render anymore, because of outdated use of properties on the `resolver` object.

I was testing with the 'enhance playlist' feature, and noticed toggling the feature required a reload to show up in the UI. Would be nice to automatically reload Spotify on closing the popup window, but I don't see a way to detect the window closing.
Also the 'Show "Made For You" entry point in the left sidebar' feature seems to be broken, not sure if we can do anything about that.