### PR TITLE
CSS map: update `main-rootlist-wrapper`

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -904,6 +904,7 @@
     "C6Q_uSufk1zE4WuU3i5P": "main-rootlist-textWrapper",
     "Z_dt4_lb43xDgDSsyDo8": "main-rootlist-topSentinel",
     "iDlSBR5JgCntHwvGPaQk": "main-rootlist-wrapper",
+    "BZPNdKNJq8JZlMjf9MTu": "main-rootlist-wrapper",
     "EOh_IvQ_4mD_IO7WqPts": "main-seeAll-link",
     "RzpZ0LkZ0jXpxHUfv4kk": "main-shelf-header",
     "fs1TCVDHYzHZfI_TsOkw": "main-shelf-seeAll",


### PR DESCRIPTION
This class is broken since spotify `v1.1.76.447`, and the cause of https://github.com/JulienMaille/dribbblish-dynamic-theme/issues/153

Here is a screenshot of the DOM tree:
![image](https://user-images.githubusercontent.com/29760988/150679697-d200913c-5b9b-43f3-8832-a005cb0a7de3.png)

I'd also map the child elements, but I don't know the actual class names since they're not used in my scripts.