### PR TITLE
Add `spicetify` to `$PATH` for Fish shell

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,9 +31,9 @@ fi
 spicetify_install="$HOME/.spicetify"
 path="export PATH=\"\$PATH:\$HOME/.spicetify\""
 
-if [[ -f "$HOME/.bashrc" ]] && ! grep -q "$path" "$HOME/.bashrc"; then echo "${path}" >>"$HOME/.bashrc" && echo "SAVING         ${spicetify_install} to \$PATH"; fi
-if [[ -f "$HOME/.zshrc" ]] && ! grep -q "$path" "$HOME/.zshrc"; then echo "${path}" >>"$HOME/.zshrc" && echo "SAVING         ${spicetify_install} to \$PATH"; fi
-if [[ -f "$HOME/.config/fish/config.fish" ]] && ! grep -q "$path" "$HOME/.config/fish/config.fish"; then echo "${path}" >>"$HOME/.config/fish/config.fish" && echo "SAVING         ${spicetify_install} to \$PATH"; fi
+if [[ -f "$HOME/.bashrc" ]] && ! grep -q "$path" "$HOME/.bashrc"; then echo "${path}" >>"$HOME/.bashrc" && echo "SAVING         ${spicetify_install} to \$PATH (bash)"; fi
+if [[ -f "$HOME/.zshrc" ]] && ! grep -q "$path" "$HOME/.zshrc"; then echo "${path}" >>"$HOME/.zshrc" && echo "SAVING         ${spicetify_install} to \$PATH (zsh)"; fi
+if [[ -f "$HOME/.config/fish/config.fish" ]] && ! grep -q "$path" "$HOME/.config/fish/config.fish"; then echo "${path}" >>"$HOME/.config/fish/config.fish" && echo "SAVING         ${spicetify_install} to \$PATH (fish)"; fi
 
 exe="$spicetify_install/spicetify"
 

--- a/install.sh
+++ b/install.sh
@@ -33,6 +33,7 @@ path="export PATH=\"\$PATH:\$HOME/.spicetify\""
 
 if [[ -f "$HOME/.bashrc" ]] && ! grep -q "$path" "$HOME/.bashrc"; then echo "${path}" >>"$HOME/.bashrc" && echo "SAVING         ${spicetify_install} to \$PATH"; fi
 if [[ -f "$HOME/.zshrc" ]] && ! grep -q "$path" "$HOME/.zshrc"; then echo "${path}" >>"$HOME/.zshrc" && echo "SAVING         ${spicetify_install} to \$PATH"; fi
+if [[ -f "$HOME/.config/fish/config.fish" ]] && ! grep -q "$path" "$HOME/.config/fish/config.fish"; then echo "${path}" >>"$HOME/.config/fish/config.fish" && echo "SAVING         ${spicetify_install} to \$PATH"; fi
 
 exe="$spicetify_install/spicetify"
 


### PR DESCRIPTION
This adds `spicetify` to the `$PATH` for the Fish shell. 
I also added the shell to the echo line, for people who have more than one shell rc file. This way it doesn't output the same message multiple times, which could be confusing. 

Reference: https://fishshell.com/docs/current/faq.html#how-do-i-run-a-command-every-login-what-s-fish-s-equivalent-to-bashrc-or-profile