### PR TITLE
Fix broken link to installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Supports Windows, MacOS and Linux.
 - Inject Custom apps
 - Remove bloated components to improve performance
 
-#### [Installation](https://spicetify.app/docs/getting-started/installation)
+#### [Installation](https://spicetify.app/docs/getting-started/simple-installation)
+#### [Advanced Installation](https://spicetify.app/docs/getting-started/advanced-installation)
 #### [Basic Usage](https://spicetify.app/docs/getting-started/basic-usage)
 #### [Customization](https://spicetify.app/docs/development/customization)
 #### [Extensions](https://spicetify.app/docs/getting-started/extensions)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Supports Windows, MacOS and Linux.
 - Remove bloated components to improve performance
 
 #### [Installation](https://spicetify.app/docs/getting-started/simple-installation)
-#### [Advanced Installation](https://spicetify.app/docs/getting-started/advanced-installation)
 #### [Basic Usage](https://spicetify.app/docs/getting-started/basic-usage)
 #### [Customization](https://spicetify.app/docs/development/customization)
 #### [Extensions](https://spicetify.app/docs/getting-started/extensions)


### PR DESCRIPTION
Link to installation on website was broken (probably due to splitting it up into simple and advanced installation). Added a link for both simple and advanced installation