### PR TITLE
fix: issue where lyrics-plus was stuck on restricted lyrics in Musixmatch

### DIFF
--- a/CustomApps/lyrics-plus/ProviderMusixmatch.js
+++ b/CustomApps/lyrics-plus/ProviderMusixmatch.js
@@ -37,6 +37,11 @@ const ProviderMusixmatch = (function () {
                 error: `Requested error: ${body["matcher.track.get"].message.header.mode}`,
                 uri: info.uri,
             };
+        } else if (body["track.lyrics.get"]?.message?.body?.lyrics?.restricted) {
+            return {
+                error: "Unfortunately we're not authorized to show these lyrics.",
+                uri: info.uri,
+            };
         }
 
         return body;


### PR DESCRIPTION
Added check to see if track is restricted, returned error if it is to go to next provider.