### PR TITLE
fix: issue where new `Spicetify.ContextMenu` items were not added to the now playing song in the bottom.

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -812,6 +812,8 @@ Spicetify.ContextMenu = (function () {
             uris = props.uris;
         } else if (props.uri) {
             uris = [props.uri];
+        } else if (props.item?.uri) {
+            uris = [props.item.uri];
         } else {
             return;
         }
@@ -819,9 +821,16 @@ Spicetify.ContextMenu = (function () {
             uids = props.uids;
         } else if (props.uid) {
             uids = [props.uid];
+        } else if (props.item?.uid) {
+            uids = [props.item.uid];
         }
-        contextUri = props?.contextUri;
 
+        if (props.contextUri) {
+            contextUri = props?.contextUri;
+        } else if (props.context?.uri) {
+            contextUri = props.context.uri;
+        }
+        
         const elemList = [];
         for (const item of itemList) {
             if (!item.shouldAdd(uris, uids, contextUri)) {


### PR DESCRIPTION
For the now playing song, the properties of the event were a bit changed, so added an exception.