### PR TITLE
Changed selector for focusOnApp() in keyboardShortcuts.js

### DIFF
--- a/Extensions/keyboardShortcut.js
+++ b/Extensions/keyboardShortcut.js
@@ -205,7 +205,7 @@
     }
 
     function focusOnApp() {
-        return document.querySelector("main .os-viewport");
+        return document.querySelector(".Root__main-view .os-viewport");
     }
 
     /**


### PR DESCRIPTION
I noticed that the keymaps for scrolling stopped working in the current release.
 
- Spotify version: Spotify for macOS (Apple Silicon) 1.1.79.763.gc2965cdf
- Spicetify version: 2.9.1

The current version of `keyboardShortcut.js` uses the selector `main .os-viewport` (which no longer exists) to focus the main container before scrolling, switching the selector to `.Root__main-view .os-viewport` solved the issue for me.
Using only `.os-viewport` as the selector can be to general since it also matches the sidebar.

![Screenshot 2022-02-21 at 21 32 40](https://user-images.githubusercontent.com/36083692/155024951-cc4701a2-be15-483b-b1c6-deb1ed88b0cd.png)
